### PR TITLE
Métrica de tempo para a primeira resposta

### DIFF
--- a/gitlab-listener/main.py
+++ b/gitlab-listener/main.py
@@ -13,6 +13,7 @@ from metric.ci_result import compute_cr
 from metric.closure_time import ClosureTime
 from metric.commits_number import compute_cn
 from metric.effective_comments import EffectiveComments
+from metric.first_human_response import compute_fhr
 from metric.first_response_time import FirstResponseTime
 from metric.general_comments import GeneralComments
 from metric.jobs_number import compute_jn
@@ -47,6 +48,7 @@ if __name__ == '__main__':
         compute_bn(merge_requests)
         compute_cr(merge_requests)
         compute_cn(merge_requests)
+        compute_fhr(merge_requests)
         compute_jn(project, merge_requests)
         compute_mn(merge_requests)
         compute_sccn(merge_requests)

--- a/gitlab-listener/metric/first_human_response.py
+++ b/gitlab-listener/metric/first_human_response.py
@@ -1,0 +1,24 @@
+import re
+from datetime import datetime
+
+bot_codacy = "codacy-bot|Codacy"
+datetime_format = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+def created_at_key(note):
+    return note.created_at
+
+
+def compute_fhr(merge_requests):
+    for merge_request in merge_requests:
+        notes = []
+        for note in merge_request.notes.list():
+            test_bot = re.findall(bot_codacy, note.body)
+            if not note.system and not test_bot:
+                notes.append(note)
+
+        if notes:
+            notes.sort(key=created_at_key)
+            start_datetime = datetime.strptime(merge_request.created_at, datetime_format)
+            end_datetime = datetime.strptime(notes[0].created_at, datetime_format)
+            print(end_datetime - start_datetime)


### PR DESCRIPTION
Foi implementada a métrica de cálculo do tempo decorrido entre a criação
do merge request e o primeiro comentário.

closes #13